### PR TITLE
try py3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
           env: TEST_UNIT=1 TEST_INSTALL=1
         - python: "3.6"
           env: TEST_UNIT=1
+        - python: "3.7-dev"
+          env: TEST_UNIT=1
 
 before_install:
     - SRC_DIR=$(pwd)

--- a/pscript/commonast.py
+++ b/pscript/commonast.py
@@ -802,6 +802,10 @@ class NativeAstConverter:
     
     def _convert_Module(self, n):
         node = Module([])
+        # Add back the "docstring" that Python removed; this may actually be
+        # a code snippet and not a module.
+        if pyversion > (3, 7) and n.docstring:
+            node.body_nodes.append(Expr(Str(n.docstring)))
         self._stack.append((node.body_nodes, n.body))
         return node
     
@@ -1161,6 +1165,8 @@ class NativeAstConverter:
             for x in node.arg_nodes + node.kwarg_nodes:
                 assert isinstance(x, Arg)
         
+        if pyversion > (3, 7) and n.docstring:
+            node.body_nodes.append(Expr(Str(n.docstring)))
         self._stack.append((node.body_nodes, n.body))
         return node
     
@@ -1212,5 +1218,7 @@ class NativeAstConverter:
         node = ClassDef(n.name, [c(a) for a in n.decorator_list],
                         arg_nodes, kwarg_nodes, [])
         
+        if pyversion > (3, 7) and n.docstring:
+            node.body_nodes.append(Expr(Str(n.docstring)))
         self._stack.append((node.body_nodes, n.body))
         return node

--- a/pscript/tests/test_parser3.py
+++ b/pscript/tests/test_parser3.py
@@ -802,7 +802,7 @@ class TestStrMethods:
     def test_that_all_str_methods_are_tested(self):
         tested = set([x.split('_')[1] for x in dir(self) if x.startswith('test_')])
         needed = set([x for x in dir(str) if not x.startswith('_')])
-        ignore = 'encode decode format_map isprintable maketrans'
+        ignore = 'encode decode format_map isprintable maketrans isascii'
         needed = needed.difference(ignore.split(' '))
         
         not_tested = needed.difference(tested)

--- a/pscript/tests/test_stdlib.py
+++ b/pscript/tests/test_stdlib.py
@@ -50,7 +50,8 @@ def test_stdlib_has_all_str_methods():
     else:
         ignore = 'encode format_map isprintable maketrans isascii'
     for name in ignore.split(' '):
-        method_names.remove(name)
+        if name in method_names:
+            method_names.remove(name)
     for method_name in method_names:
         assert method_name in stdlib.METHODS
 

--- a/pscript/tests/test_stdlib.py
+++ b/pscript/tests/test_stdlib.py
@@ -48,7 +48,7 @@ def test_stdlib_has_all_str_methods():
     if sys.version_info[0] == 2:
         ignore = 'encode decode'
     else:
-        ignore = 'encode format_map isprintable maketrans'
+        ignore = 'encode format_map isprintable maketrans isascii'
     for name in ignore.split(' '):
         method_names.remove(name)
     for method_name in method_names:


### PR DESCRIPTION
~~Oh: "Constant folding is moved from peephole optimizer to new AST optimizer. (Contributed by Eugene Toder and INADA Naoki in bpo-29469)"~~

Nope, the problem was that docstrings are removed as expressions but end up as a `docstring`  attribute on the ast node of module/function/class. I made commonast revert this.