### PR TITLE
Reverse argument assignment order

### DIFF
--- a/pscript/parser2.py
+++ b/pscript/parser2.py
@@ -934,17 +934,17 @@ class Parser2(Parser1):
             if not node.kwargs_node:
                 code.append(", '%s'" % func_name or 'anonymous')
             code.append(');')
+            if vararg_code2:
+                code.append(self.lf(vararg_code2))
             # Apply values of positional args
             # inside if, because standard arguments are invalid
             args_var = 'arguments[0].flx_args'
             if len(argnames) > 1:
                 args_var = self.dummy('args')
                 code.append(self.lf('%s = arguments[0].flx_args;' % args_var))
-            for i, name in enumerate(argnames):
+            for i, name in reversed(list(enumerate(argnames))):
                 code.append(self.lf('%s = %s[%i];' % (name, args_var, i)))
             # End if
-            if vararg_code2:
-                code.append(self.lf(vararg_code2))
             self._indent -= 1
             code.append(self.lf('}'))
             if vararg_code1:


### PR DESCRIPTION
Fixes #23
**Problem:**
```
def partial2(a1, a2, *args, **kwargs):
    print(a1, a2)
    print(args)
    print(kwargs)
```
The original order of assignment is **kwargs, a1, a2, *args.
But after assigning arg1 (which is `arguments[0]`) we cannot get more arguments.

**Solution:**
Assign everything in reverse order: **kwargs, *args, arg2, arg1.
So we "break" `arguments[0]` at the very end when we don't need it anymore.