### PR TITLE
Support `base` arg of `int` (parseInt way)

### DIFF
--- a/pscript/stdlib.py
+++ b/pscript/stdlib.py
@@ -305,7 +305,8 @@ FUNCTIONS['sum'] = """function (x) {  // nargs: 1
 
 FUNCTIONS['round'] = 'Math.round // nargs: 1'
 
-FUNCTIONS['int'] = """function (x) { // nargs: 1
+FUNCTIONS['int'] = """function (x, base) { // nargs: 1 2
+    if(base !== undefined) return parseInt(x, base);
     return x<0 ? Math.ceil(x): Math.floor(x);
 }"""
 


### PR DESCRIPTION
Can convert expressions with specified radix:
```
int('0xab', 0)  # =171 (base is got from expression)
# int('0b0101', 0) is not supported
int('ab', 16)  # =171
```
fixes #21 

P. S. `int()` returns 0 in Python and NaN in pscript