### PR TITLE
Performance tweaks for addition of numbers

### DIFF
--- a/pscript/parser1.py
+++ b/pscript/parser1.py
@@ -733,7 +733,8 @@ class Parser1(Parser0):
         value = ''.join(self.parse(node.value_node))
         
         nl = self.lf()
-        if node.op == node.OPS.Add and not isinstance(node.value_node, (ast.Num, ast.Str)):
+        if node.op == node.OPS.Add and not isinstance(node.value_node,
+                                                      (ast.Num, ast.Str)):
             return [nl, target, ' = ',
                     self.use_std_function('op_add', [target, value]), ';']
         elif node.op == node.OPS.Mult:

--- a/pscript/parser1.py
+++ b/pscript/parser1.py
@@ -383,7 +383,12 @@ class Parser1(Parser0):
         
         if node.op == node.OPS.Add:
             C = ast.Num, ast.Str
-            if not (isinstance(node.left_node, C) or isinstance(node.right_node, C)):
+            if not (isinstance(node.left_node, C) or
+                    isinstance(node.right_node, C) or
+                    (isinstance(node.left_node, ast.BinOp) and
+                        node.left_node.op == node.OPS.Add and "op_add" not in left) or
+                    (isinstance(node.right_node, ast.BinOp) and
+                        node.right_node.op == node.OPS.Add and "op_add" not in right)):
                 return self.use_std_function('op_add', [left, right])
         elif node.op == node.OPS.Mult:
             C = ast.Num
@@ -728,7 +733,7 @@ class Parser1(Parser0):
         value = ''.join(self.parse(node.value_node))
         
         nl = self.lf()
-        if node.op == node.OPS.Add:
+        if node.op == node.OPS.Add and not isinstance(node.value_node, (ast.Num, ast.Str)):
             return [nl, target, ' = ',
                     self.use_std_function('op_add', [target, value]), ';']
         elif node.op == node.OPS.Mult:

--- a/pscript/parser3.py
+++ b/pscript/parser3.py
@@ -265,7 +265,7 @@ class Parser3(Parser2):
             # proposed, which might be better in theory, but is > 50% slower
             return ["({}).toString.call(",
                     ob,
-                    ").match(/\s([a-zA-Z]+)/)[1].toLowerCase() === ",
+                    r").match(/\s([a-zA-Z]+)/)[1].toLowerCase() === ",
                     "'%s'" % cmp.lower()
                     ]
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@
 # ignores:
 # W291 trailing whitespace
 # W293 blanc line contains whitespace
+# W504 line break after binary operator
 #
 # E124 closing bracket does not match visual indentation
 # E127 continuation line over-indented for visual indent
@@ -30,8 +31,8 @@
 exclude: test_*.py,exp/*,docs/*,build/*,dist/*,pscript_legacy/*,_feedstock/*,
   python_sample.py,python_sample2.py,python_sample3.py,
 
-ignore: W291,W293,E123,E124,E126,E127,E203,E225,E226,E265,E301,E302,E303,E402,
-    E266,E731,E128,E306,E305,I,D,T,CG,N8
+ignore: W291,W293,W504,E123,E124,E126,E127,E203,E225,E226,E265,E301,E302,E303,E402,
+    E266,E731,E128,E306,E305,I,D,T,CG,N8,S
 
 max-line-length: 88
 


### PR DESCRIPTION
```
a = b + 3  # was already good by detecting ast Num/Str node
a = b + 3 + a  # would work for one of the additions but not the other
a += 3  # was also wrapped in a pyfunc_op_add
```