### PR TITLE
Allow to rename functions starting with an uppercase letter

### DIFF
--- a/pscript/functions.py
+++ b/pscript/functions.py
@@ -147,7 +147,7 @@ def py2js(ob=None, new_name=None, **parser_options):
 
 re_sub1 = re.compile(r'this\.__(\w*?[a-zA-Z0-9](?!__)\W)', re.UNICODE)
 
-def js_rename(jscode, cur_name, new_name, type):
+def js_rename(jscode, cur_name, new_name, type=None):
     """ Rename a function or class in a JavaScript code string.
     
     The new name can be prefixed (i.e. have dots in it). Functions can be
@@ -159,14 +159,18 @@ def js_rename(jscode, cur_name, new_name, type):
         jscode (str): the JavaScript source code
         cur_name (str): the current name (must be an identifier, e.g. no dots).
         new_name (str): the name to replace the current name with
-        type (str): the Python object type, either 'class' or 'def'
+        type (str): the Python object type, can be 'class' or 'def'. If None,
+          the type is inferred from the object name based on PEP8
     
     Returns:
         str: the modified JavaScript source code
     """
     assert cur_name and '.' not in cur_name
     
-    isclass = type == 'class'
+    if type:
+        isclass = type == 'class'
+    else:
+        isclass = cur_name[0].lower() != cur_name[0]  # For backward compat.
     if isclass:
         # cur_cls_name = cur_name
         new_cls_name = new_name.split('.')[-1]

--- a/pscript/functions.py
+++ b/pscript/functions.py
@@ -114,7 +114,7 @@ def py2js(ob=None, new_name=None, **parser_options):
         if new_name:
             if thetype not in ('class', 'def'):
                 raise TypeError('py2js() can only rename functions and classes.')
-            jscode = js_rename(jscode, ob.__name__, new_name)
+            jscode = js_rename(jscode, ob.__name__, new_name, thetype)
         
         # Collect undefined variables
         # vars_unknown = [name for name, s in p.vars.get_undefined()]
@@ -147,7 +147,7 @@ def py2js(ob=None, new_name=None, **parser_options):
 
 re_sub1 = re.compile(r'this\.__(\w*?[a-zA-Z0-9](?!__)\W)', re.UNICODE)
 
-def js_rename(jscode, cur_name, new_name):
+def js_rename(jscode, cur_name, new_name, type):
     """ Rename a function or class in a JavaScript code string.
     
     The new name can be prefixed (i.e. have dots in it). Functions can be
@@ -159,13 +159,14 @@ def js_rename(jscode, cur_name, new_name):
         jscode (str): the JavaScript source code
         cur_name (str): the current name (must be an identifier, e.g. no dots).
         new_name (str): the name to replace the current name with
+        type (str): the Python object type, either 'class' or 'def'
     
     Returns:
         str: the modified JavaScript source code
     """
     assert cur_name and '.' not in cur_name
     
-    isclass = cur_name[0].lower() != cur_name[0]
+    isclass = type == 'class'
     if isclass:
         # cur_cls_name = cur_name
         new_cls_name = new_name.split('.')[-1]

--- a/pscript/tests/test_functions.py
+++ b/pscript/tests/test_functions.py
@@ -142,6 +142,10 @@ def foo1():
 def foo2(self):
     return self.__x + self.__y__
 
+# Function name not compliant with PEP8 but that happens.
+def Foo3():
+    return 'a'
+
 
 def test_py2js_rename_class():
     
@@ -162,6 +166,10 @@ def test_py2s_rename_function():
     code = py2js(foo1, 'xx.bar')
     assert 'foo' not in code.lower()
     assert evaljs('var xx={};\n' + code + 'xx.bar();') == '42'
+
+    code = py2js(Foo3, 'bar')
+    assert 'foo' not in code.lower()
+    assert evaljs(code + 'bar()') == 'a'
     
 
 def test_py2s_rename_function_to_method():


### PR DESCRIPTION
Python functions declared with a name starting with an uppercase letter do not seem to be properly renamed. This bug appeared here: https://github.com/holoviz/holoviews/issues/4394