### PR TITLE
Preserve full qualited import name for browser

### DIFF
--- a/pscript/modules.py
+++ b/pscript/modules.py
@@ -145,7 +145,7 @@ def create_js_module(name, code, imports, exports, type='umd'):
     # Derived information needed to populate the module templates
     save_name = lambda n: n.split('/')[-1].split('.')[0].replace('-', '_')
     dep_strings = ['"%s"' % dep for dep in deps]
-    dep_fullnames = ['root.' + save_name(dep) for dep in deps]
+    dep_fullnames = ['root.' + dep for dep in deps]
     dep_requires = ['require("%s")' % dep for dep in deps]
     
     # Fill in the template


### PR DESCRIPTION
Preserver full object name with dotted name (eg module_2.MyClass).
So import in browser also will be like
```
root.module_1 = factory(root.module_2.MyClass);
```
when imports is `["module_2.MyClass as MyClass"]`