### PR TITLE
Add rudimentary support for python files that use type hints

### DIFF
--- a/pscript/commonast.py
+++ b/pscript/commonast.py
@@ -1034,6 +1034,12 @@ class NativeAstConverter:
     def _convert_AugAssign(self, n):
         op = n.op.__class__.__name__
         return AugAssign(self._convert(n.target), op, self._convert(n.value))
+
+    def _convert_AnnAssign(self, n):
+        if n.value is None:
+            raise RuntimeError("Cannot convert AnnAssign nodes with no assignment!")
+        c = self._convert
+        return Assign([c(n.target)], c(n.value))
     
     def _convert_Print(self, n):  # pragma: no cover - Python 2.x compat
         c = self._convert

--- a/pscript/parser1.py
+++ b/pscript/parser1.py
@@ -850,6 +850,9 @@ class Parser1(Parser0):
             return []  # stuff to help the parser
         if node.root == 'time':
             return []  # PScript natively supports time() and perf_counter()
+        if node.root == 'typing':
+            # User is probably importing type annotations. Ignore this import.
+            return []
         raise JSError('PScript does not support imports.')
     
     def parse_Module(self, node):

--- a/pscript/tests/test_commonast.py
+++ b/pscript/tests/test_commonast.py
@@ -379,4 +379,22 @@ def test_python_33_plus():
     assert isinstance(node, commonast.YieldFrom)
 
 
+@skipif(sys.version_info < (3,5), reason='Need Python 3.5+')
+def test_annotated_assignments():
+    # Verify that we treat annotated assignments as regular assingments
+    code = "foo: int = 3"
+    node = commonast.parse(code).body_nodes[0]
+
+    assert isinstance(node, commonast.Assign)
+    assert len(node.target_nodes) == 1
+    assert isinstance(node.target_nodes[0], commonast.Name)
+    assert node.target_nodes[0].name == "foo"
+    assert isinstance(node.value_node, commonast.Num)
+    assert node.value_node.value == 3
+
+    # Verify that we do not support annotated assignments with no value
+    with raises(RuntimeError):
+        commonast.parse("foo: int")
+
+
 run_tests_if_main()


### PR DESCRIPTION
Pretty much as it says on the tin. I was adding type hints to a small python library that used pscript (https://github.com/DragonMinded/firebeatrtc) and when I went to regenerate the js I ran into lack of support for AnnAssign. This is incredibly basic support, since I don't bother to do anything with AnnAssign nodes that don't actually assign a value (like `x: int`) aside from raising an exception. I also threw in a hack to allow importing from "typing" as a whitelisted import with similar rationale to the existing whitelisted entries.

Do I have to edit other parsers with similar whitespace or run any tests? I didn't run anything aside from seeing that after this change, pscript successfully generated the js file exactly as I expected it to.