### PR TITLE
Replace ast.Ellipsis with ast.Constant

### DIFF
--- a/pscript/commonast.py
+++ b/pscript/commonast.py
@@ -1032,7 +1032,7 @@ class NativeAstConverter:
 
     def _convert_index_like(self, n):
         c = self._convert
-        if isinstance(n, (ast.Slice, ast.Index, ast.ExtSlice, ast.Ellipsis)):
+        if isinstance(n, (ast.Slice, ast.Index, ast.ExtSlice, ast.Constant)):
             return c(n)  # Python < 3.8 (and also 3.8 on Windows?)
         elif isinstance(n, ast.Tuple):
             assert isinstance(n, ast.Tuple)


### PR DESCRIPTION
Fixes issue with Python 3.14

```bash
[....]
       > self = <pscript.commonast.NativeAstConverter object at 0x7ffff48143d0>
       > n = Constant(value='a', kind=None)
       >
       >     def _convert_index_like(self, n):
       >         c = self._convert
       > >       if isinstance(n, (ast.Slice, ast.Index, ast.ExtSlice, ast.Ellipsis)):
       >                                                               ^^^^^^^^^^^^
       > E       AttributeError: module 'ast' has no attribute 'Ellipsis'
       >
       > pscript/commonast.py:1035: AttributeError
       > =========================== short test summary info ============================
       > FAILED tests/test_commonast.py::test_consistent_ast1 - AttributeError: module 'ast' has no attribute 'Ellipsis'
       > FAILED tests/test_parser1.py::TestExpressions::test_indexing_and_slicing - AttributeError: module 'ast' has no attribute 'Ellipsis'
       > FAILED tests/test_parser1.py::TestExpressions::test_assignments - AttributeError: module 'ast' has no attribute 'Ellipsis'
       > FAILED tests/test_parser1.py::TestExpressions::test_dict_literals - AttributeError: module 'ast' has no attribute 'Ellipsis'
       > FAILED tests/test_parser1.py::TestExpressions::test_funcion_call - AttributeError: module 'ast' has no attribute 'Ellipsis'
       > FAILED tests/test_parser1.py::TestExpressions::test_delete - AttributeError: module 'ast' has no attribute 'Ellipsis'
       > FAILED tests/test_parser2.py::TestConrolFlow::test_for - AttributeError: module 'ast' has no attribute 'Ellipsis'
       > FAILED tests/test_parser2.py::TestConrolFlow::test_listcomp_regressions - AttributeError: module 'ast' has no attribute 'Ellipsis'
       > FAILED tests/test_parser3.py::TestOtherBuiltins::test_repr - AttributeError: module 'ast' has no attribute 'Ellipsis'
       > FAILED tests/test_parser3.py::TestDictMethods::test_copy - AttributeError: module 'ast' has no attribute 'Ellipsis'
       > ================ 10 failed, 213 passed, 1 deselected in 31.37s =================
``